### PR TITLE
Issue #2512720 : Expose EntityBrowser Upload plugin configuration

### DIFF
--- a/src/Plugin/EntityBrowser/Widget/Upload.php
+++ b/src/Plugin/EntityBrowser/Widget/Upload.php
@@ -7,6 +7,7 @@
 namespace Drupal\media_entity_image\Plugin\EntityBrowser\Widget;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\entity_browser\Plugin\EntityBrowser\Widget\Upload as FileUpload;
 
 /**
@@ -36,11 +37,11 @@ class Upload extends FileUpload {
   public function getForm(array &$original_form, FormStateInterface $form_state, array $aditional_widget_parameters) {
     /** @var \Drupal\media_entity\MediaBundleInterface $bundle */
     if (!$this->configuration['media bundle'] || !($bundle = $this->entityManager->getStorage('media_bundle')->load($this->configuration['media bundle']))) {
-      return ['#markup' => t('The media bundle is not configured correctly.')];
+      return ['#markup' => $this->t('The media bundle is not configured correctly.')];
     }
 
     if ($bundle->getType()->getPluginId() != 'image') {
-      return ['#markup' => t('The configured bundle is not using image plugin.')];
+      return ['#markup' => $this->t('The configured bundle is not using image plugin.')];
     }
 
     $form = parent::getForm($original_form, $form_state, $aditional_widget_parameters);
@@ -72,6 +73,51 @@ class Upload extends FileUpload {
 
     $this->selectEntities($images, $form_state);
     $this->clearFormValues($element, $form_state);
+  }
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['extensions'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Allowed extensions'),
+      '#default_value' => $this->configuration['extensions'],
+      '#required' => TRUE,
+    ];
+
+    $bundle_options = [];
+
+    $bundles = $this
+      ->entityManager
+      ->getStorage('media_bundle')
+      ->loadByProperties(['type' => 'image']);
+
+    foreach ($bundles as $bundle) {
+      $bundle_options[$bundle->id()] = $bundle->label();
+    }
+
+    switch (count($bundle_options)) {
+      case 0:
+        $url = Url::fromRoute('media.bundle_add')->toString();
+        $form['media bundle'] = [
+          '#markup' => $this->t("You don't have media bundle of the Image type. You should <a href='!link'>create one</a>", ['!link' => $url]),
+        ];
+        break;
+
+      case 1:
+        $form['media bundle'] = array(
+          '#value' => key($bundle_options),
+        );
+        break;
+
+      default:
+        $form['media bundle'] = array(
+          '#type' => 'select',
+          '#title' => $this->t('Media bundle'),
+          '#default_value' => $this->configuration['media bundle'],
+          '#options' => $bundle_options,
+        );
+    }
+
+    return $form;
   }
 
 }


### PR DESCRIPTION
Issue at: https://www.drupal.org/node/2512720

Attached the patch in the issue, but opening a PR too, just in case. Can be discussed where you like it best :-)

From the comment posted there:

I'm still wondering about a few things in this patch though:
-    Not sure about what would be best in case 0 ; current action match Entity Browser "your view is incorrectly configured, go fix it" behavior, and makes the site builder next step obvious, but I'm not sure having them lose the configuration of the entity browser in the process might not be ideal.
-   Left the current "upload path" configuration in place ; not sure that's a good idea though, defaulting to the path set in the source field is probably better for most workflow

Thought about those two points more than welcome.

(Sidenote: also converted two remaining t() call to $this->t() , thought it wasn't worth it's own dedicated issue, but can be split if you want)
